### PR TITLE
Allow list-groups in panels, make panel-body optional

### DIFF
--- a/dev/snippets/panel/list-group.cljs
+++ b/dev/snippets/panel/list-group.cljs
@@ -1,0 +1,11 @@
+#_
+(:require [om-bootstrap.panel :as p]
+          [om-tools.dom :as d :include-macros true])
+
+(p/panel
+  {:header "List group panel"
+   :list-group (d/ul {:class "list-group"}
+                   (d/li {:class "list-group-item"} "Item 1")
+                   (d/li {:class "list-group-item"} "Item 2")
+                   (d/li {:class "list-group-item"} "Item 3"))}
+  nil)

--- a/docs/src/cljs/om_bootstrap/docs/components.cljs
+++ b/docs/src/cljs/om_bootstrap/docs/components.cljs
@@ -205,6 +205,10 @@
    are not meant to be in the foreground.")
    (->example (slurp-example "panel/footer"))
 
+   (d/h3 "Panel with list group")
+   (d/p "Put full-width list-groups in your panel with the " (d/code ":list-group") "option.")
+   (->example (slurp-example "panel/list-group"))
+
    (d/h3 "Contextual alternatives")
    (d/p "Like other components, make a panel more meaningful to a
    particular context by adding a " (d/code ":bs-style") " prop.")

--- a/src/om_bootstrap/panel.cljs
+++ b/src/om_bootstrap/panel.cljs
@@ -12,7 +12,8 @@
   (t/bootstrap
    {:on-select (sm/=> s/Any s/Any)
     :header t/Renderable
-    :footer t/Renderable}))
+    :footer t/Renderable
+    (s/optional-key :list-group) t/Renderable}))
 
 (sm/defn panel :- t/Component
   [opts :- Panel & children]
@@ -24,7 +25,9 @@
            (when-let [header (:header bs)]
              (d/div {:class "panel-heading"}
                     (u/clone-with-props header {:class "panel-title"})))
-           (d/div {:class "panel-body" :ref "body"}
-                  children)
+           (when-not (= 0 (count (filter identity children)))
+             (d/div {:class "panel-body" :ref "body"} children))
+           (when-let [list-group (:list-group bs)]
+             list-group)
            (when-let [footer(:footer bs)]
              (d/div {:class "panel-footer"} footer)))))


### PR DESCRIPTION
Bootstrap example is [here](http://getbootstrap.com/components/#panels-list-group)

I haven't been able to actually see the docs build result. How do I do it once I've run `lein with-profile docs cljsbuild`?
