### PR TITLE
make Om a provided dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 0.3.3 (1/21/2015)
-- Turned Om into a provided dependency.
+## 0.3.4
+
+- Turned Om into a provided dependency (https://github.com/racehub/om-bootstrap/pull/44)
+- add Pagination, thanks to @dignati (https://github.com/racehub/om-bootstrap/pull/47)
+- Fixes a bug where navs were un-expanded by default (https://github.com/racehub/om-bootstrap/pull/48)
 
 ## 0.3.3 (1/13/2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.3 (1/21/2015)
+- Turned Om into a provided dependency.
+
 ## 0.3.3 (1/13/2015)
 
 - Added collapse functionality for navbars (https://github.com/racehub/om-bootstrap/pull/41)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ These, and the mixins below, are the project's biggest TODOs.
 * Subnav (?)
 * Panel (hard), PanelGroup (easy), Accordion (easy)
 * TabbedArea, TabPane
-* Pager
 * Carousel
 * CarouselItem
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Here's the latest Leiningen version info:
 
 [![Clojars Project](http://clojars.org/racehub/om-bootstrap/latest-version.svg)](http://clojars.org/racehub/om-bootstrap)
 
+You'll also need to add Om:
+
+```clojure
+[om "0.7.3"]
+```
+
 You can find more detailed information on how to configure your Clojurescript project to use Om-Bootstrap on the documentation site's [Getting Started section](http://om-bootstrap.herokuapp.com/getting-started).
 
 **This is an alpha release. The API and organizational structure are

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [prismatic/om-tools "0.3.6" :exclusions [om]]
                  [prismatic/schema "0.3.1"
                   :exclusions [org.clojure/clojurescript]]
-                 [om "0.7.1"]]
+                 [om "0.7.1" :scope "provided"]]
   :profiles {:provided
              {:dependencies [[org.clojure/clojurescript "0.0-2411"]
                              [secretary "1.2.0"]


### PR DESCRIPTION
Since David added `org.om` as a prefix, the two versions of Om clash with each other.