### PR TITLE
Support for collapsible panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ These, and the mixins below, are the project's biggest TODOs.
 
 * FadeMixin
 * OverlayMixin
-* CollapsibleMixin
 
 ## ClojureScript Repl
 

--- a/dev/snippets/panel/collapsible.cljs
+++ b/dev/snippets/panel/collapsible.cljs
@@ -1,0 +1,2 @@
+(om-bootstrap.panel/collapsible-panel {:header "Collapse Me!"}
+                                      (d/span "Sometimes I'm here, sometimes I'm not"))

--- a/dev/snippets/panel/collapsible.cljs
+++ b/dev/snippets/panel/collapsible.cljs
@@ -1,5 +1,6 @@
 #_
 (:require [om-bootstrap.panel :as p])
 
-(p/collapsible-panel {:header "Collapse Me!"}
-                     (d/span "Sometimes I'm here, sometimes I'm not"))
+(p/panel {:header "Collapse Me!"
+          :collapsible? true}
+         (d/span "Sometimes I'm here, sometimes I'm not"))

--- a/dev/snippets/panel/collapsible.cljs
+++ b/dev/snippets/panel/collapsible.cljs
@@ -1,2 +1,5 @@
-(om-bootstrap.panel/collapsible-panel {:header "Collapse Me!"}
-                                      (d/span "Sometimes I'm here, sometimes I'm not"))
+#_
+(:require [om-bootstrap.panel :as p])
+
+(p/collapsible-panel {:header "Collapse Me!"}
+                     (d/span "Sometimes I'm here, sometimes I'm not"))

--- a/docs/src/cljs/om_bootstrap/docs/components.cljs
+++ b/docs/src/cljs/om_bootstrap/docs/components.cljs
@@ -214,6 +214,11 @@
    particular context by adding a " (d/code ":bs-style") " prop.")
    (->example (slurp-example "panel/contextual"))
 
+   (d/h3 "Collapsible panels")
+   (d/p "This panel is collapsed by default and can be extended by clicking
+   on the title")
+   (->example (slurp-example "panel/collapsible"))
+
    (d/h3 "Controlled PanelGroups")
    (d/p (d/code "p/panel-group") "s can be controlled by a parent
    component. The " (d/code ":active-key") " prop dictates which panel

--- a/src/om_bootstrap/mixins.cljs
+++ b/src/om_bootstrap/mixins.cljs
@@ -103,3 +103,14 @@
      (bind-root-close-handlers! owner)
      (unbind-root-close-handlers! owner))
    (om/set-state! owner [:open?] open?)))
+
+
+(defmixin collapsible-mixin
+  "Mixin that enables collapsible Panels. Similar to the Dropdown
+   Mixin it only manages a single piece of state - :collapsed?. The Panel
+   is opened and closen by clicking on the header."
+  (init-state [_] {:collapsed? false})
+  (isPanelCollapsed [owner] (om/get-state owner :collapsed?))
+  (toggleCollapsed
+    [owner]
+    (om/update-state! owner [:collapsed?] not)))

--- a/src/om_bootstrap/panel.cljs
+++ b/src/om_bootstrap/panel.cljs
@@ -17,25 +17,31 @@
     (s/optional-key :header) t/Renderable
     (s/optional-key :footer) t/Renderable
     (s/optional-key :list-group) t/Renderable
+    (s/optional-key :collapsible?) s/Bool
     (s/optional-key :collapsed?) s/Bool}))
+
+(declare ->collapsible-panel*)
 
 (sm/defn panel :- t/Component
   [opts :- Panel & children]
   (let [[bs props] (t/separate Panel opts {:bs-class "panel"
                                            :bs-style "default"})
         classes (assoc (t/bs-class-set bs) :panel true)]
-    (d/div (u/merge-props props {:class (d/class-set classes)})
-           (when-let [header (:header bs)]
-             (d/div {:class "panel-heading"}
-                    (u/clone-with-props header {:class "panel-title"})))
-           (when-not (= 0 (count (filter identity children)))
-             (d/div {:class (str "panel-body" (when (:collapsed? bs) " collapse"))
-                     :ref "body"}
-                    children))
-           (when-let [list-group (:list-group bs)]
-             list-group)
-           (when-let [footer (:footer bs)]
-             (d/div {:class "panel-footer"} footer)))))
+    (if (:collapsible? bs)
+      (->collapsible-panel* {:opts     (dissoc opts :collapsible?)
+                            :children children})
+      (d/div (u/merge-props props {:class (d/class-set classes)})
+             (when-let [header (:header bs)]
+               (d/div {:class "panel-heading"}
+                      (u/clone-with-props header {:class "panel-title"})))
+             (when-not (= 0 (count (filter identity children)))
+               (d/div {:class (str "panel-body" (when (:collapsed? bs) " collapse"))
+                       :ref   "body"}
+                      children))
+             (when-let [list-group (:list-group bs)]
+               list-group)
+             (when-let [footer (:footer bs)]
+               (d/div {:class "panel-footer"} footer))))))
 
 ;; ## Collapsible Panel
 
@@ -55,9 +61,3 @@
       (panel (u/merge-props opts {:header collapsible-header
                                   :collapsed? is-collapsed?})
              children))))
-
-(sm/defn collapsible-panel :- t/Component
-  "Returns a collapsible panel"
-  [opts :- Panel & children]
-  (->collapsible-panel* {:opts opts
-                         :children children}))

--- a/src/om_bootstrap/panel.cljs
+++ b/src/om_bootstrap/panel.cljs
@@ -56,7 +56,7 @@
                                   :collapsed? is-collapsed?})
              children))))
 
-(s/defn collapsible-panel :- t/Component
+(sm/defn collapsible-panel :- t/Component
   "Returns a collapsible panel"
   [opts :- Panel & children]
   (->collapsible-panel* {:opts opts


### PR DESCRIPTION
This adds support for collapsible panels.

I basically just added a collapsible mixin and a collapsible-panel function to create it. I had to add the :collapsed? key to Panel opts because the the panel-body must have the class .collapsed to hide the content. 