### PR TITLE
Support for progress bars

### DIFF
--- a/dev/snippets/progressbar/active.cljs
+++ b/dev/snippets/progressbar/active.cljs
@@ -1,0 +1,4 @@
+#_
+(:require [om-bootstrap.progress-bar :as pb])
+
+(pb/progress-bar {:now 70 :active? true})

--- a/dev/snippets/progressbar/basic.cljs
+++ b/dev/snippets/progressbar/basic.cljs
@@ -1,0 +1,4 @@
+#_
+(:require [om-bootstrap.progress-bar :as pb])
+
+(pb/progress-bar {:min 0 :max 100 :now 50})

--- a/dev/snippets/progressbar/contextual.cljs
+++ b/dev/snippets/progressbar/contextual.cljs
@@ -1,0 +1,6 @@
+#_
+(:require [om-bootstrap.progress-bar :as pb])
+
+(for [context [nil "primary" "success" "info" "warning" "danger"]]
+  (pb/progress-bar (merge {:now 50 :label "50%"}
+                          (when context {:bs-style context}))))

--- a/dev/snippets/progressbar/label.cljs
+++ b/dev/snippets/progressbar/label.cljs
@@ -1,0 +1,4 @@
+#_
+(:require [om-bootstrap.progress-bar :as pb])
+
+(pb/progress-bar {:min 0 :max 100 :now 50 :label "Loading"})

--- a/dev/snippets/progressbar/sr_only_label.cljs
+++ b/dev/snippets/progressbar/sr_only_label.cljs
@@ -1,0 +1,4 @@
+#_
+(:require [om-bootstrap.progress-bar :as pb])
+
+(pb/progress-bar {:min 0 :max 100 :now 50 :label "50%" :sr-only? true})

--- a/dev/snippets/progressbar/striped.cljs
+++ b/dev/snippets/progressbar/striped.cljs
@@ -1,0 +1,4 @@
+#_
+(:require [om-bootstrap.progress-bar :as pb])
+
+(pb/progress-bar {:now 70 :striped? true})

--- a/docs/src/cljs/om_bootstrap/docs/components.cljs
+++ b/docs/src/cljs/om_bootstrap/docs/components.cljs
@@ -314,6 +314,7 @@
 
 ;; ## Progress Bars
 
+
 (defn progress-bar-block []
   (section
    "progress"
@@ -323,33 +324,33 @@
         action with simple yet flexible progress bars.")
    (d/h3 "Basic example")
    (d/p "Default progress bar.")
-   (TODO)
+   (->example (slurp-example "progressbar/basic"))
 
    (d/h3 "With label")
    (d/p "Add a " (d/code ":label") " prop to show a visible
    percentage. For low percentages, consider adding
    a" (d/code ":min-width") " to ensure the label's text is fully
    visible.")
-   (TODO)
+   (->example (slurp-example "progressbar/label"))
 
    (d/h3 "Screenreader only label")
    (d/p "Add the " (d/code ":sr-only? true") " option to hide the
    label visually.")
-   (TODO)
+   (->example (slurp-example "progressbar/sr_only_label"))
 
    (d/h3 "Contextual alternatives")
    (d/p "Progress bars use some of the same button and alert classes
    for consistent styles.")
-   (TODO)
+   (->example (slurp-example "progressbar/contextual"))
 
    (d/h3 "Striped")
    (d/p "Uses a gradient to create a striped effect. Not available in IE8.")
-   (TODO)
+   (->example (slurp-example "progressbar/striped"))
 
    (d/h3 "Animated")
    (d/p "Add the " (d/code ":active? true") " option to animate the
    stripes right to left. Not available in IE9 and below.")
-   (TODO)
+   (->example (slurp-example "progressbar/active"))
 
    (d/h3 "Stacked")
    (d/p "Nest " (d/code "pb/progress-bar") "s to stack them.")


### PR DESCRIPTION
This adds support for progress bars.

TODO:
- [x] Basic
- [x] With label
- [x] Screenreader only label
- [x] Contextual alternatives
- [x] Striped
- [x] Animated
- [ ] Stacked

I would like to get some advise on stacked  progress bars. It's not clear to me what the best way to implement them would be.