### PR TITLE
Fix expanded key on navs

### DIFF
--- a/src/om_bootstrap/nav.cljs
+++ b/src/om_bootstrap/nav.cljs
@@ -88,7 +88,8 @@
   (render
    [_]
    (let [{:keys [opts children]} (om/get-props owner)
-         [bs props] (t/separate Nav opts {:bs-class "nav"})
+         [bs props] (t/separate Nav opts {:expanded? true
+                                          :bs-class "nav"})
          classes {:navbar-collapse (:collapsible? bs)
                   :collapse (not (:expanded? bs))
                   :in (:expanded? bs)}


### PR DESCRIPTION
Fixes #43 . Once we get @dignati's #45 in, we should change this to use the collapsible mixin as well (as he does for Panels).