### PR TITLE
[WIP] Fix the repl issue due to the cljs update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   :profiles {:provided
              {:dependencies [[org.clojure/clojurescript "0.0-2760"]
                              [secretary "1.2.0"]
-                             [weasel "0.4.2"]]}
+                             [weasel "0.5.0"]]}
              ;; Change to the first version of the uberjar profile
              ;; when this bug gets fixed:
              ;; https://github.com/technomancy/leiningen/issues/1694
@@ -57,7 +57,7 @@
              :dev {:plugins [~cljsbuild
                              [com.cemerick/clojurescript.test "0.3.1"]
                              [paddleguru/lein-gitflow "0.1.2"]]
-                   :dependencies ~(conj server-deps '[com.cemerick/piggieback "0.1.3"])
+                   :dependencies ~(conj server-deps '[com.cemerick/piggieback "0.1.5"])
                    :source-paths ["docs/src/clj" "docs/src-dev"]
                    :resource-paths ["dev"]
                    :main om-bootstrap.server


### PR DESCRIPTION
Following the om update, lein repl does not work for me, with this errors:
```
CompilerException java.lang.IllegalArgumentException: Can't define method not in interfaces: _setup, compiling:(weasel/repl/websocket.clj:32:1)
```

After digging, I find similar issues:
https://github.com/cemerick/piggieback/issues/36
https://github.com/lynaghk/cljx/issues/64
https://github.com/tomjakubowski/weasel/pull/44

After bumping the weasel and piggieback versions, I have a new error:
```
om-bootstrap.server=> (require '[om-bootstrap.repl :as repl])
nil
om-bootstrap.server=> (repl/repl!)

ExceptionInfo No such namespace: cljsjs.react at line 1 file:/home/jba/.m2/repository/org/omcljs/om/0.8.8/om-0.8.8.jar!/om/dom.cljs  clojure.core/ex-info (core.clj:4554)
```

There are a fix for that too, but unfortunately it looks like this is not release yet: http://dev.clojure.org/jira/browse/CLJS-1008
