### PR TITLE
Fixed input validation example

### DIFF
--- a/dev/snippets/input/validation.cljs
+++ b/dev/snippets/input/validation.cljs
@@ -24,6 +24,7 @@
           (i/input
            {:feedback? true
             :type "text"
+            :value (:text @state)
             :label "Working example with validation"
             :placeholder "Enter text"
             :help "Validates based on string length."


### PR DESCRIPTION
The input validation example on the website was broken since the `i/input` field was not actually updating it's contents based on a user's input.

This was due to a missing `:value` key.