### PR TITLE
Fix nav item disabled

### DIFF
--- a/src/om_bootstrap/button.cljs
+++ b/src/om_bootstrap/button.cljs
@@ -52,9 +52,8 @@
                        {:active (:active? bs)
                         :btn-block (:block? bs)})]
     (cond
-     (:nav-item? bs) (d/li {:class (d/class-set {:active (:active? bs)})}
+     (:nav-item? bs) (d/li {:class (d/class-set {:active (:active? bs) :disabled? (:disabled? bs)})}
                            (render-anchor {:props props
-                                           :disabled? (:disabled? bs)
                                            :classes klasses}
                                           children))
      (or (:href props)


### PR DESCRIPTION
The disabled class should be applied to the li element rather than the embedded a element.