### PR TITLE
Fix unmounted error

### DIFF
--- a/src/om_bootstrap/button.cljs
+++ b/src/om_bootstrap/button.cljs
@@ -52,9 +52,8 @@
                        {:active (:active? bs)
                         :btn-block (:block? bs)})]
     (cond
-     (:nav-item? bs) (d/li {:class (d/class-set {:active (:active? bs)})}
+     (:nav-item? bs) (d/li {:class (d/class-set {:active (:active? bs) :disabled? (:disabled? bs)})}
                            (render-anchor {:props props
-                                           :disabled? (:disabled? bs)
                                            :classes klasses}
                                           children))
      (or (:href props)

--- a/src/om_bootstrap/mixins.cljs
+++ b/src/om_bootstrap/mixins.cljs
@@ -68,8 +68,9 @@
            (event-listener
             js/document "click"
             (fn [e]
-              (when-not (in-root? (.-target e) (om/get-node owner))
-                (set-state false))))
+              (when ((aget owner "isMounted"))
+                (when-not (in-root? (.-target e) (om/get-node owner))
+                  (set-state false)))))
            (event-listener
             js/document "keyup"
             (fn [e]


### PR DESCRIPTION
Fix error where om/get-node is called on an unmounted component in a button dropdown.