### PR TITLE
input-group-btn can be both before and after an input

### DIFF
--- a/dev/snippets/input/addons.cljs
+++ b/dev/snippets/input/addons.cljs
@@ -7,5 +7,7 @@
  (i/input {:type "text" :addon-before "@"})
  (i/input {:type "text" :addon-after ".00"})
  (i/input {:type "text" :addon-before "$" :addon-after ".00"})
- (i/input {:type "text" :addon-button
-                 (b/button {:bs-style "primary" :onClick #(js/alert "hi!")} "Click Me!")}))
+ (i/input {:type "text" :addon-button-before
+           (b/button {:bs-style "primary" :onClick #(js/alert "hi!")} "Click Me!")})
+ (i/input {:type "text" :addon-button-after
+           (b/button {:bs-style "primary" :onClick #(js/alert "hi!")} "Click Me!")}))

--- a/docs/src/cljs/om_bootstrap/docs/components.cljs
+++ b/docs/src/cljs/om_bootstrap/docs/components.cljs
@@ -613,8 +613,16 @@
    (->example (slurp-example "input/types"))
 
    (d/h3 "Add-ons")
-   (d/p "Use " (d/code ":addon-before") ", " (d/code ":addon-after") "
-   and " (d/code ":addon-button") ".")
+   (d/p
+    "Use "
+    (d/code ":addon-before")
+    ", "
+    (d/code ":addon-after")
+    ", "
+    (d/code ":addon-button-before")
+    " and "
+    (d/code ":addon-button-after")
+    ".")
    (->example (slurp-example "input/addons"))
 
    (d/h3 "Validation")

--- a/src/om_bootstrap/input.cljs
+++ b/src/om_bootstrap/input.cljs
@@ -29,7 +29,9 @@
 (def Addons
   {(s/optional-key :addon-before) (s/either s/Str t/Component)
    (s/optional-key :addon-after) (s/either s/Str t/Component)
-   (s/optional-key :addon-button) (s/either s/Str t/Component)})
+   (s/optional-key :addon-button) (s/either s/Str t/Component)
+   (s/optional-key :addon-button-before) (s/either s/Str t/Component)
+   (s/optional-key :addon-button-after) (s/either s/Str t/Component)})
 
 (def FeedbackIcons
   "Helps render feedback icons."
@@ -92,17 +94,21 @@
 
 (s/defn render-input-group
   "Items is a vector of render instances."
-  [{:keys [addon-before addon-after addon-button]} :- Addons
+  [{:keys [addon-before addon-after addon-button addon-button-before addon-button-after]} :- Addons
    items :- s/Any]
-  (if (or addon-before addon-after addon-button)
+  (if (or addon-before addon-after addon-button addon-button-before addon-button-after)
     (d/div {:class "input-group"}
            (when addon-before
              (d/span {:class "input-group-addon"} addon-before))
+           (when addon-button-before
+             (d/span {:class "input-group-btn"} addon-button-before))
            items
            (when addon-after
              (d/span {:class "input-group-addon"} addon-after))
            (when addon-button
-             (d/span {:class "input-group-btn"} addon-button)))
+             (d/span {:class "input-group-btn"} addon-button))
+           (when addon-button-after
+             (d/span {:class "input-group-btn"} addon-button-after)))
     items))
 
 (s/defn checkbox-or-radio? :- s/Bool
@@ -189,7 +195,7 @@
            (render-form-group input))
       (->> [(render-label input)
             (->> [(render-input-group
-                   (select-keys input [:addon-before :addon-after :addon-button])
+                   (select-keys input [:addon-before :addon-after :addon-button :addon-button-before :addon-button-after])
                    (render-input input attrs children))
                   (render-icon (select-keys input [:feedback? :bs-style]))
                   (render-help (:help input))]


### PR DESCRIPTION
I've added addon-button-before and addon-button-after to Input. I left the existing addon-button option to input to prevent any backwards incompatible issues, but addon-button and addon-button-after are effectively the same.