### PR TITLE
Pass opts to pagination's nav

### DIFF
--- a/src/om_bootstrap/pagination.cljs
+++ b/src/om_bootstrap/pagination.cljs
@@ -29,6 +29,6 @@
   (page (assoc opts :aria-label "Next") (d/span {:aria-hidden "true"} "»")))
 
 (s/defn pagination :- t/Component [opts & children]
-  (d/nav
+  (d/nav opts
     (d/ul {:class "pagination"}
           children)))


### PR DESCRIPTION
Use case for this is to pass a class of text-center to the containing nav, to center the pagination.