### PR TITLE
Upgrade project dependencies; replace weasel with figwheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dev/public/assets/generated
 .idea
 *.iml
 *-init.clj
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.6.0 (2/2/2016)
+
+- Major Changes:
+- Upgrade Clojure to 1.8
+- Upgrade Clojurescript to 1.7.228
+- Replace Weasel/Piggieback with Figwheel
+- Several other minor dependency upgrades
+
 ## 0.5.3 (7/13/2015)
 
 - Change `map` to `doseq` in unbind-root-close-handlers to force effects (https://github.com/racehub/om-bootstrap/pull/76)

--- a/README.md
+++ b/README.md
@@ -81,14 +81,7 @@ lein repl
 
 You'll be dropped into the `om-bootstrap.server` namespace. Fire up the webapp by running `(-main)`. You can access the dev site at `http://localhost:8080`. (Set the `PORT` environment variable to customize the launch port.)
 
-Next, require the `repl` namespace and boot the Clojurescript repl:
-
-```clojure
-(require '[om-bootstrap.repl :as repl])
-(repl/repl!)
-```
-
-This will start a Websocket repl using [Weasel](https://github.com/tomjakubowski/weasel). When you reload `http://localhost:8080`, it should automatically connect to Weasel and anything you type at the repl will start evaluating.
+Next, to fire up a Clojurescript repl you can use `lein figwheel`. This will start a Websocket repl using [Figwheel](https://github.com/bhauman/lein-figwheel). When you reload `http://localhost:8080`, it should automatically connect to Figwheel and anything you type at the repl will start evaluating.
 
 I personally like to start the repl with `lein repl :headless` and do all of this from Emacs. Whatever floats your boat.
 

--- a/docs/src-dev/om_bootstrap/repl.clj
+++ b/docs/src-dev/om_bootstrap/repl.clj
@@ -1,8 +1,0 @@
-(ns om-bootstrap.repl
-  (:require [cemerick.piggieback :as p]
-            [weasel.repl.websocket :as w]))
-
-(defn repl!
-  "Starts a Clojurescript repl."
-  []
-  (p/cljs-repl :repl-env (w/repl-env)))

--- a/docs/src/cljs/om_bootstrap/docs.cljs
+++ b/docs/src/cljs/om_bootstrap/docs.cljs
@@ -10,8 +10,7 @@
             [om-bootstrap.docs.shared :refer [four-oh-four]]
             [om-tools.core :refer-macros [defcomponentk]]
             [om-tools.dom :as d :include-macros true]
-            [secretary.core :as route :refer-macros [defroute]]
-            [weasel.repl :as ws-repl])
+            [secretary.core :as route :refer-macros [defroute]])
   (:require-macros [cljs.core.async.macros :refer [go-loop]])
   (:import [goog.history EventType]))
 
@@ -72,8 +71,6 @@
   "Loading actions for the main docs page."
   []
   (route/dispatch! (-> js/window .-location .-pathname))
-  (setup-app)
-  (when-not (ws-repl/alive?)
-    (ws-repl/connect "ws://localhost:9001" :verbose true)))
+  (setup-app))
 
 (on-load)

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
     [http-kit "2.1.19"]
     [hiccup "1.0.5"]])
 
-(defproject racehub/om-bootstrap "0.5.4-SNAPSHOT"
+(defproject racehub/om-bootstrap "0.6.0-SNAPSHOT"
   :description "Bootstrap meets Om."
   :url "http://github.com/racehub/om-bootstrap"
   :license {:name "MIT License"

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
 (def cljsbuild
-  '[lein-cljsbuild "1.0.4" :exclusions [org.clojure/clojurescript]])
+  '[lein-cljsbuild "1.1.2" :exclusions [org.clojure/clojurescript]])
 
 (def server-deps
   '[[javax.servlet/servlet-api "2.5"]
-    [compojure "1.1.8"]
-    [http-kit "2.1.18"]
+    [compojure "1.4.0"]
+    [http-kit "2.1.19"]
     [hiccup "1.0.5"]])
 
 (defproject racehub/om-bootstrap "0.5.4-SNAPSHOT"
@@ -18,16 +18,15 @@
   :min-lein-version "2.3.0"
   :uberjar-name "om-bootstrap.jar"
   :jar-exclusions [#".DS_Store"]
-  :dependencies [[org.clojure/clojure "1.7.0-alpha2"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.2.374"]
                  [prismatic/om-tools "0.3.11" :exclusions [om]]
                  [prismatic/schema "0.4.0"
                   :exclusions [org.clojure/clojurescript]]
                  [org.omcljs/om "0.8.8" :scope "provided"]]
   :profiles {:provided
-             {:dependencies [[org.clojure/clojurescript "0.0-2760"]
-                             [secretary "1.2.0"]
-                             [weasel "0.5.0"]]}
+             {:dependencies [[org.clojure/clojurescript "1.7.228"]
+                             [secretary "1.2.3"]]}
              ;; Change to the first version of the uberjar profile
              ;; when this bug gets fixed:
              ;; https://github.com/technomancy/leiningen/issues/1694
@@ -56,13 +55,12 @@
                     :resource-paths ["dev"]}
              :dev {:plugins [~cljsbuild
                              [com.cemerick/clojurescript.test "0.3.1"]
-                             [paddleguru/lein-gitflow "0.1.2"]]
-                   :dependencies ~(conj server-deps '[com.cemerick/piggieback "0.1.5"])
+                             [paddleguru/lein-gitflow "0.1.2"]
+                             [lein-figwheel "0.5.0-6"]]
+                   :dependencies ~server-deps
                    :source-paths ["docs/src/clj" "docs/src-dev"]
                    :resource-paths ["dev"]
-                   :main om-bootstrap.server
-                   :repl-options
-                   {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}}}
+                   :main om-bootstrap.server}}
   :aliases {"test" ["cljsbuild" "test"]
             ;; We'll change this for the next new alpha that comes out.
             ;; "test-8" ["do" "clean," "cljsbuild" "clean," "with-profile" "+om-8" "cljsbuild" "test"]
@@ -78,6 +76,7 @@
    :builds
    {:docs
     {:source-paths ["src" "docs/src/cljs" "docs/src/clj"]
+     :figwheel true
      :compiler {:output-to "dev/public/assets/main.js"
                 :output-dir "dev/public/generated"
                 :optimizations :none


### PR DESCRIPTION
Several major dependency upgrades - now using the latest stable versions of both Clojure and ClojureScript. Also replaced the Weasel/Piggieback combo with Figwheel.

Should fix #87 and #86 