### PR TITLE
Upgrade prismatic schema

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.2.374"]
                  [prismatic/om-tools "0.3.11" :exclusions [om]]
-                 [prismatic/schema "0.4.0"
+                 [prismatic/schema "1.1.1"
                   :exclusions [org.clojure/clojurescript]]
                  [org.omcljs/om "0.8.8" :scope "provided"]]
   :profiles {:provided

--- a/src/om_bootstrap/input.cljs
+++ b/src/om_bootstrap/input.cljs
@@ -27,11 +27,11 @@
 ;; ### Schema
 
 (def Addons
-  {(s/optional-key :addon-before) (s/either s/Str t/Component)
-   (s/optional-key :addon-after) (s/either s/Str t/Component)
-   (s/optional-key :addon-button) (s/either s/Str t/Component)
-   (s/optional-key :addon-button-before) (s/either s/Str t/Component)
-   (s/optional-key :addon-button-after) (s/either s/Str t/Component)})
+  {(s/optional-key :addon-before) (s/cond-pre s/Str t/Component)
+   (s/optional-key :addon-after) (s/cond-pre s/Str t/Component)
+   (s/optional-key :addon-button) (s/cond-pre s/Str t/Component)
+   (s/optional-key :addon-button-before) (s/cond-pre s/Str t/Component)
+   (s/optional-key :addon-button-after) (s/cond-pre s/Str t/Component)})
 
 (def FeedbackIcons
   "Helps render feedback icons."
@@ -66,7 +66,7 @@
   represents the final class to apply.
 
   TODO: Use class-set from om-tools."
-  [klasses :- {(s/either s/Str s/Keyword) s/Bool}]
+  [klasses :- {(s/cond-pre s/Str s/Keyword) s/Bool}]
   (->> (mapcat (fn [[k keep?]]
                  (when keep? [(name k)]))
                klasses)

--- a/src/om_bootstrap/nav.cljs
+++ b/src/om_bootstrap/nav.cljs
@@ -49,7 +49,7 @@
 (def Nav
   (t/bootstrap
    {:bs-style (s/enum "tabs" "pills")
-    (s/optional-key :active-key) (s/either s/Str s/Num)
+    (s/optional-key :active-key) (s/cond-pre s/Str s/Num)
     (s/optional-key :active-href) s/Str
     (s/optional-key :stacked?) s/Bool
     (s/optional-key :justified?) s/Bool
@@ -171,7 +171,7 @@
   "Returns true if any of the necessary properties are in place to
   render the navbar-header and toggle button."
   [bs]
-  (boolean 
+  (boolean
     (or (:brand bs)
         (:toggle-button bs)
         (:toggle-nav-key bs))))


### PR DESCRIPTION
Also, replace the deprecated `either` schema command with the much more
efficient `cond-pre`, which for all the cases it was used before will
behave identically.

Was getting tired of seeing the deprecated warnings from the project I'd imported this into, which I had to pull a later version of schema to fix some AOT compilation issues.
